### PR TITLE
Fix documentation about AAAA record

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ To make up a domain that resolves only to an IPv6 address, use the following syn
 
 `make-ip-v6-<IP>-rr.1u.ms`
 
-Colons must be replaced with letter `c`. As always, random prefix and suffix can be used:
+Colons must be replaced with letter `l`. As always, random prefix and suffix can be used:
 
 ```shell
-$ host -t AAAA prefix-make-ip-v6-1c2cc3-rr-suffix.1u.ms
-prefix-make-ip-v6-1c2cc3-rr-suffix.1u.ms has IPv6 address 1:2::3
+$ host -t AAAA prefix-make-ip-v6-1l2ll3-rr-suffix.1u.ms
+prefix-make-ip-v6-1l2ll3-rr-suffix.1u.ms has IPv6 address 1:2::3
 ```
 
 #### CNAMEs


### PR DESCRIPTION
The current AAAA-record documentation appears to be wrong, it suggests using `c` in place of `:` for IPv6, but the example does not work:

```sh
$ host -t AAAA prefix-make-ip-v6-1c2cc3-rr-suffix.1u.ms
prefix-make-ip-v6-1c2cc3-rr-suffix.1u.ms has no AAAA record
```

[By checking the code](https://github.com/neex/1u.ms/blob/eb63d5321c8fc9cad9b19381f5eef05a69de4e0d/processors.go#L194), it appears the correct character to use in place of column is actually `l`, and indeed it works using that:

```sh
host -t AAAA prefix-make-ip-v6-1l2ll3-rr-suffix.1u.ms
prefix-make-ip-v6-1l2ll3-rr-suffix.1u.ms has IPv6 address 1:2::3
```

I just updated the README to reflect the correct character.